### PR TITLE
BSON encoder/decoder

### DIFF
--- a/META.list
+++ b/META.list
@@ -64,6 +64,7 @@ https://github.com/arnsholt/Algorithm-Viterbi/raw/master/META.info
 https://github.com/moritz/Nonogram/raw/master/META.info
 https://github.com/moritz/CGI-Application/raw/master/META.info
 https://github.com/bbkr/jsonrpc/raw/master/META.info
+https://raw.github.com/bbkr/BSON/master/META.info
 https://github.com/perlpilot/benchmark/raw/master/META.info
 https://github.com/ihrd/uri/raw/master/META.info
 https://github.com/leto/perl6-Algorithm-Soundex/raw/master/META.info


### PR DESCRIPTION
BSON format is used mostly by popular MongoDB database (I plan to start work on MongoDB driver for P6 soon).

Mapping from/to basic Perl 6 types is working, classes such as ObjectId will follow.
