### PR TITLE
Added Test::Junkie to META.list

### DIFF
--- a/META.list
+++ b/META.list
@@ -111,3 +111,4 @@ https://raw.github.com/perl6/ecosystem/master/SHELTER/link-c/META.info
 https://raw.github.com/perl6/ecosystem/master/SHELTER/Vector/META.info
 https://raw.github.com/zag/plosurin/master/META.info
 https://raw.github.com/retupmoca/p6-Email-Simple/master/META.info
+https://raw.github.com/gam/Test-Junkie/master/META.info


### PR DESCRIPTION
Adding Test::Junkie - a continuous test runner for Perl6 with the initial implementation a conversion of masak's mini-tote.pl to a module.

Requires a post April 21st build of Rakudo. Depends on Perl 5 'prove' for test running.  
