### PR TITLE
Add Enc::MIME::Base64 module

### DIFF
--- a/META.list
+++ b/META.list
@@ -116,3 +116,4 @@ https://raw.github.com/afiskon/p6-datetime-format-w3cdtf/master/META.info
 https://raw.github.com/Cofyc/perl6-redis/master/META.info
 https://raw.github.com/flussence/perl6-XMMS2/master/META.info
 https://raw.github.com/afiskon/p6-sitemap-xml-parser/master/META.info
+https://raw.github.com/ronaldxs/perl6-Enc-MIME-Base64/master/META.info


### PR DESCRIPTION
See end of README.md for explanation of why Perl 6 wants another MIME Base64 encoder.
