### PR TITLE
Update META.list

### DIFF
--- a/META.list
+++ b/META.list
@@ -124,3 +124,4 @@ https://raw.github.com/FROGGS/p6-File-Spec/master/META.info
 https://raw.github.com/FROGGS/p6-Inline-C/master/META.info
 https://raw.github.com/perlpilot/p6-Locale-US/master/META.info
 https://raw.github.com/MattOates/Text--Emotion/master/META.info
+https://raw.github.com/grondilu/openssl/master/META.info


### PR DESCRIPTION
perl6 interface to openssl, so far only a few digests.  Needs small modification of code for big-endian hosts.
