### PR TITLE
Add the perl6-IUP module.

### DIFF
--- a/META.list
+++ b/META.list
@@ -164,3 +164,4 @@ https://raw.github.com/arnsholt/Net-ZMQ/master/META.info
 https://raw.github.com/coke/p6-lingua-en-syllable/master/META.info
 https://raw.github.com/tadzik/File-HomeDir/master/META.info
 https://raw.github.com/tadzik/pandabrew/master/META.info
+https://raw.github.com/mrhdias/perl6-IUP/master/META.info


### PR DESCRIPTION
Add the perl6-IUP module the Perl 6 interface to the IUP toolkit for building GUI's.
