### PR TITLE
Add PerlMongers::Hannover to ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -250,3 +250,4 @@ https://raw2.github.com/tony-o/perl6-db-orm-quicky/master/META.info
 https://raw2.github.com/tony-o/perl6-pandapack/master/META.info
 https://raw2.github.com/jnthn/oo-monitors/master/META.info
 https://raw2.github.com/jnthn/oo-actors/master/META.info
+https://raw2.github.com/paultcochrane/Perl6Mongers-Hannover/master/META.info


### PR DESCRIPTION
This module is intended as the perl6 version of the equivalent PerlMonger::Hannover perl5 module.
