### PR TITLE
META.list: Add Net::Packet and Net::Pcap

### DIFF
--- a/META.list
+++ b/META.list
@@ -263,3 +263,4 @@ https://raw.githubusercontent.com/sillymoose/URI-Encode/master/META.info
 https://raw.githubusercontent.com/sillymoose/System-Passwd/master/META.info
 https://raw.githubusercontent.com/sillymoose/Software-License/master/META.info
 https://raw.githubusercontent.com/jpve/perl6-net-packet/master/META.info
+https://raw.githubusercontent.com/jpve/perl6-net-pcap/master/META.info


### PR DESCRIPTION
Adds Net::Packet and Net::Pcap to META.list.
