### PR TITLE
Adds Editsrc::Uggedit to META.list

### DIFF
--- a/META.list
+++ b/META.list
@@ -328,3 +328,4 @@ https://raw.githubusercontent.com/tony-o/perl6-http-server-logger/master/META.in
 https://raw.githubusercontent.com/p6-pdf/perl6-Font-AFM/master/META.info
 https://raw.githubusercontent.com/zostay/p6-HTTP-Headers/master/META.info
 https://raw.githubusercontent.com/zostay/p6-Hash-MultiValue/master/META.info
+https://github.com/Uladox/Editscr-Uggedit/blob/master/META.info


### PR DESCRIPTION
Adds the Editsrc::Uggedit module to the module list. The module is, "The obvious in-source Perl6 based solution to avoid repetion in modifing text by using embedded code with your languages of choice, or just scanning using a perl6 module."