### PR TITLE
Add new module: Pekyll

### DIFF
--- a/META.list
+++ b/META.list
@@ -368,3 +368,4 @@ https://raw.githubusercontent.com/perlpilot/p6-IO-Notification-Recursive/master/
 https://raw.githubusercontent.com/zostay/P6SGI/master/META.info
 https://raw.githubusercontent.com/yuvipanda/perl6-Ident-Client/master/META.info
 https://raw.githubusercontent.com/jonathanstowe/XDG-BaseDirectory/master/META.info
+https://raw.githubusercontent.com/nunorc/p6-Pekyll/master/META.info


### PR DESCRIPTION
Add module https://github.com/nunorc/p6-Pekyll to the list. 