### PR TITLE
Added Raw::Socket

### DIFF
--- a/META.list
+++ b/META.list
@@ -371,3 +371,4 @@ https://raw.githubusercontent.com/jonathanstowe/XDG-BaseDirectory/master/META.in
 https://raw.githubusercontent.com/nunorc/p6-Pekyll/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-green/master/META.info
 https://raw.githubusercontent.com/shoichikaji/mi6/master/META.info
+https://raw.githubusercontent.com/tokuhirom/p6-Raw-Socket/master/META.info


### PR DESCRIPTION
Raw::Socket is a low level BSD socket wrapper using NativeCall.