### PR TITLE
Take over maintenance of perl6-pod-to-markdown

### DIFF
--- a/META.list
+++ b/META.list
@@ -281,7 +281,7 @@ https://raw.githubusercontent.com/jpve/perl6-net-packet/master/META.info
 https://raw.githubusercontent.com/jpve/perl6-net-pcap/master/META.info
 https://raw.githubusercontent.com/jpve/perl6-pod-strip/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-slang-sql/master/META.info
-https://raw.githubusercontent.com/jpve/perl6-pod-to-markdown/master/META.info
+https://raw.githubusercontent.com/softmoth/perl6-pod-to-markdown/master/META.info
 https://raw.githubusercontent.com/marcoonroad/Coro-Simple/master/META.info
 https://raw.githubusercontent.com/p6-css/perl6-CSS-Writer/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-http-server-async-plugins-router-simple/master/META.info


### PR DESCRIPTION
It appears that jpve is not available to maintain the module at this time, given no response on pull requests for over 3 months. I am willing to maintain the module in the mean time.