### PR TITLE
add TXN

### DIFF
--- a/META.list
+++ b/META.list
@@ -481,3 +481,4 @@ https://raw.githubusercontent.com/Skarsnik/perl6-discord/master/META.info
 https://raw.githubusercontent.com/Juerd/p6-mqtt/master/META.info
 https://raw.githubusercontent.com/perlpilot/p6-Test-Class/master/META6.json
 https://raw.githubusercontent.com/autarch/perl6-Pod-TreeWalker/master/META.info
+https://raw.githubusercontent.com/atweiden/mktxn/master/META.info


### PR DESCRIPTION
[TXN](https://github.com/atweiden/mktxn),  a double-entry bookkeeping TXN parser / serializer.