### PR TITLE
Added RPi::Device::DS18B20 to ecosystem.

### DIFF
--- a/META.list
+++ b/META.list
@@ -491,3 +491,4 @@ https://raw.githubusercontent.com/zoffixznet/perl6-IRC-Client-Plugin-HNY/master/
 https://raw.githubusercontent.com/nkh/P6-Data-Dump-Tree/v1.0.0/META.info
 https://raw.githubusercontent.com/autarch/perl6-File-LibMagic/master/META.info
 https://raw.githubusercontent.com/bradclawsie/Hash-Consistent/master/META.info
+https://raw.githubusercontent.com/cspencer/perl6-raspberry-pi-device-ds18b20/master/META.info


### PR DESCRIPTION
RPi::Device::DS18B20 provides support for the DS18B20 family of temperature sensors.