### PR TITLE
add the Email::Notmuch module

### DIFF
--- a/META.list
+++ b/META.list
@@ -506,3 +506,4 @@ https://raw.githubusercontent.com/scmorrison/perl6-aws-pricing/master/META.info
 https://raw.githubusercontent.com/zoffixznet/perl6-Test-Output/master/META.info
 https://raw.githubusercontent.com/jonathanstowe/IO-Path-Mode/master/META.info
 https://raw.githubusercontent.com/hoelzro/p6-native-resources/master/META.info
+https://raw.githubusercontent.com/goneri/p6-Email-Notmuch/master/META.info


### PR DESCRIPTION
Email::Notmuch is a binding for the NotmuchMail mail search library.

  https://notmuchmail.org/