### PR TITLE
Add perl6-slang-roman

### DIFF
--- a/META.list
+++ b/META.list
@@ -332,6 +332,7 @@ https://raw.githubusercontent.com/stmuk/p6-Text-VimColour/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-http-server-threaded/master/META.info
 https://raw.githubusercontent.com/zostay/Template-Anti/master/META.info
 https://raw.githubusercontent.com/drforr/perl6-readline/master/META.info
+https://raw.githubusercontent.com/drforr/perl6-slang-roman/master/META.info
 https://raw.githubusercontent.com/zostay/p6-Path-Router/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-http-server-router/master/META.info
 https://raw.githubusercontent.com/skids/perl6xproto/master/META.info


### PR DESCRIPTION
Arguably it should be an Acme:: module, but let me know what you think.