### PR TITLE
Add Attrx::PrivateAccessor to ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -525,3 +525,4 @@ https://raw.githubusercontent.com/gfldex/perl6-typesafe-html/master/META.info
 https://raw.githubusercontent.com/gfldex/perl6-typesafe-xhtml-writer/master/META.info
 https://raw.githubusercontent.com/Skarsnik/p6-linux-proc-statm/master/META6.json
 https://raw.githubusercontent.com/peelle/Finance-CompoundInterest/master/META.info
+https://raw.githubusercontent.com/pierre-vigier/Perl6-AttrX-PrivateAccessor/master/META.info


### PR DESCRIPTION
Automatic creation of private accessor for private attribute
See: https://github.com/pierre-vigier/Perl6-AttrX-PrivateAccessor