### PR TITLE
apologies, fixed package repo name

### DIFF
--- a/META.list
+++ b/META.list
@@ -532,5 +532,5 @@ https://raw.githubusercontent.com/Leont/build-graph6/master/META6.json
 https://raw.githubusercontent.com/Leont/build-simple6/master/META6.json
 https://raw.githubusercontent.com/pmqs/Archive-SimpleZip/master/META.info
 https://raw.githubusercontent.com/jonathanstowe/Tinky/master/META.info
-https://raw.githubusercontent.com/bradclawsie/WebService-AWS-V4/master/META.info
+https://raw.githubusercontent.com/bradclawsie/WebService-AWS-Auth-V4/master/META.info
 


### PR DESCRIPTION
Sorry, I forgot a path element in my package name in the URL. Fixed now and old URL will redirect.