### PR TITLE
Add Acme::Mangle

### DIFF
--- a/META.list
+++ b/META.list
@@ -546,3 +546,4 @@ https://raw.githubusercontent.com/pierre-vigier/Perl6-AttrX-Lazy/master/META6.js
 https://raw.githubusercontent.com/zoffixznet/perl6-Inline-Brainfuck/master/META6.json
 https://raw.githubusercontent.com/gotoexit/Concurrent-BoundedChannel/master/META.info
 https://raw.githubusercontent.com/MadcapJake/p6dx/master/META.info
+https://raw.githubusercontent.com/MadcapJake/Acme-Mangle/master/META.info


### PR DESCRIPTION
A libtranslate wrapper that mangles text similarly to yoleaux's `.mangle` command