### PR TITLE
Add RPI::Wiring::Pi to the ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -565,3 +565,5 @@ https://raw.githubusercontent.com/johnspurr/Lingua-EN-Stem-Porter/master/META6.j
 https://raw.githubusercontent.com/jonathanstowe/Audio-Playlist-JSPF/master/META6.json
 https://raw.githubusercontent.com/garyaj/perl6-raspberry-pi-device-piface/master/META6.json
 https://raw.githubusercontent.com/dbrunton/Automata-Cellular/master/META6.json
+https://raw.githubusercontent.com/Sufrostico/perl6-wiringpi/master/META.info
+


### PR DESCRIPTION
See https://github.com/Sufrostico/perl6-wiringpi/

Perl6 wrapper for the wiringpi C library (http://wiringpi.com)