### PR TITLE
Update Crypt::Bcrypt

### DIFF
--- a/META.list
+++ b/META.list
@@ -244,7 +244,7 @@ https://raw.githubusercontent.com/perl6/gtk-simple/master/META6.json
 https://raw.githubusercontent.com/timo/cairo-p6/master/META6.json
 https://raw.githubusercontent.com/tadzik/ClassX-StrictConstructor/master/META.info
 https://raw.githubusercontent.com/stmuk/p6-String-Koremutake/master/META6.json
-https://raw.githubusercontent.com/carbin/p6-Crypt-Bcrypt/master/META.info
+https://raw.githubusercontent.com/skinkade/p6-Crypt-Bcrypt/master/META.info
 https://raw.githubusercontent.com/xfix/Acme-DSON/master/META.info
 https://raw.githubusercontent.com/MattOates/Stats/master/META.info
 https://raw.githubusercontent.com/teodozjan/lacuna-cookbuk/master/META.info


### PR DESCRIPTION
Old version no longer works. This is a re-write with a simpler API and updated crypt_blowfish library.