### PR TITLE
new module Semaphore::ReadersWriters

### DIFF
--- a/META.list
+++ b/META.list
@@ -24,6 +24,7 @@ https://raw.githubusercontent.com/jnthn/test-mock/master/META.info
 https://raw.githubusercontent.com/cjfields/bioperl6/master/META.info
 https://raw.githubusercontent.com/MattOates/BioInfo/master/META.info
 https://raw.githubusercontent.com/sergot/Term--ProgressBar/master/META.info
+https://raw.githubusercontent.com/MARTIMM/semaphore-readerswriters/master/META.info
 https://raw.githubusercontent.com/MARTIMM/config-datalang-refine/master/META.info
 https://raw.githubusercontent.com/sergot/IO-Capture-Simple/master/META.info
 https://raw.githubusercontent.com/FCO/Math-PascalTriangle/master/META.info


### PR DESCRIPTION
Semaphore readers writers pattern also called  lightswitch