### PR TITLE
Desktop::Notify is a set of simple bindings to libnotify using Native…

### DIFF
--- a/META.list
+++ b/META.list
@@ -680,3 +680,4 @@ https://raw.githubusercontent.com/Altai-man/perl6-Test-NoTabs/master/META6.json
 https://raw.githubusercontent.com/zoffixznet/perl6-RT-REST-Client/master/META6.json
 https://gitlab.com/samcns/uzu/raw/master/META6.json
 https://raw.githubusercontent.com/gfldex/perl6-pod-to-bigpage/master/META.info
+https://raw.githubusercontent.com/frithnanth/perl6-Desktop-Notify/master/META6.json


### PR DESCRIPTION
…Call.

See: https://github.com/frithnanth/perl6-Desktop-Notify