### PR TITLE
Add Getopt::Std - POSIX getopt(3) options processing.

### DIFF
--- a/META.list
+++ b/META.list
@@ -684,3 +684,4 @@ https://raw.githubusercontent.com/frithnanth/perl6-Desktop-Notify/master/META6.j
 https://raw.githubusercontent.com/zoffixznet/perl6-Ecosystem-Test/master/META6.json
 https://raw.githubusercontent.com/ppentchev/perl6-Test-Deeply-Relaxed/master/META6.json
 https://raw.githubusercontent.com/bduggan/p6-oauth2-client-google/master/META.json
+https://raw.githubusercontent.com/ppentchev/perl6-Getopt-Std/master/META6.json


### PR DESCRIPTION
Hi,

This module provides a getopts() function somewhat similar to the one in Perl 5's Getopt::Std module.  I needed one since I want all my programs, in whatever language they may be written, to have the same command-line interface - for both finger memory and automated testing.

Thanks in advance for considering Yet Another Getopt::*  Module! :)

G'luck,
Peter