### PR TITLE
PKCS #5 with PBKDF2

### DIFF
--- a/META.list
+++ b/META.list
@@ -697,3 +697,4 @@ https://raw.githubusercontent.com/melezhik/sparrowdo-nginx/master/META.info
 https://raw.githubusercontent.com/melezhik/sparrowdo-sparrow-update/master/META.info
 https://raw.githubusercontent.com/shantanubhadoria/p6-Printer-ESCPOS/master/META6.json
 https://raw.githubusercontent.com/shantanubhadoria/p6-CompUnit-Search/master/META6.json
+https://raw.githubusercontent.com/MARTIMM/PKCS5/master/META.info


### PR DESCRIPTION
Partly implemented PKCS #5 with Key derivation function PBKDF2 from RFC2898