### PR TITLE
Sparrowdo module to install CPAN modules using App::cpm - a fast CPAN module installer.

### DIFF
--- a/META.list
+++ b/META.list
@@ -699,3 +699,5 @@ https://raw.githubusercontent.com/shantanubhadoria/p6-Printer-ESCPOS/master/META
 https://raw.githubusercontent.com/shantanubhadoria/p6-CompUnit-Search/master/META6.json
 https://raw.githubusercontent.com/MARTIMM/PKCS5/master/META.info
 https://raw.githubusercontent.com/pierre-vigier/Perl6-Acme-Sudoku/master/META6.json
+https://raw.githubusercontent.com/melezhik/sparrowdo-cpm/master/META.info
+


### PR DESCRIPTION
Sparrowdo module to install CPAN modules using App::cpm - a fast CPAN module installer.