### PR TITLE
Add IRC::Client::Plugin::UserPoints

### DIFF
--- a/META.list
+++ b/META.list
@@ -714,3 +714,4 @@ https://raw.githubusercontent.com/atweiden/txn-remarshal/master/META.info
 https://raw.githubusercontent.com/zostay/HTTP-Request-Supply/master/META6.json
 https://raw.githubusercontent.com/LLFourn/p6-DispatchMap/master/META6.json
 https://raw.githubusercontent.com/slobo/Perl6-X11-Xlib-Raw/master/META6.json
+https://raw.githubusercontent.com/jsimonet/IRC-Client-Plugin-UserPoints/master/META6.json


### PR DESCRIPTION
This is a plugin for IRC::Client, counting points attributed to users.