### PR TITLE
PRECIS framework

### DIFF
--- a/META.list
+++ b/META.list
@@ -722,3 +722,4 @@ https://raw.githubusercontent.com/titsuki/p6-Algorithm-LBFGS/master/META6.json
 https://raw.githubusercontent.com/leejo/geo-ip2location-lite-p6/master/META6.json
 https://raw.githubusercontent.com/zostay/p6-Getopt-ForClass/master/META6.json
 https://raw.githubusercontent.com/FCO/ProblemSolver/master/META.info
+https://raw.githubusercontent.com/MARTIMM/unicode-precis/master/META.info


### PR DESCRIPTION
Implementation of PRECIS framework implementing  rfc7564. Also rfc7613 etc. obsoleting stringprep and saslprep.