### PR TITLE
Add JS::Minify module

### DIFF
--- a/META.list
+++ b/META.list
@@ -722,3 +722,4 @@ https://raw.githubusercontent.com/leejo/geo-ip2location-lite-p6/master/META6.jso
 https://raw.githubusercontent.com/zostay/p6-Getopt-ForClass/master/META6.json
 https://raw.githubusercontent.com/FCO/ProblemSolver/master/META.info
 https://raw.githubusercontent.com/MARTIMM/unicode-precis/master/META.info
+https://raw.githubusercontent.com/scmorrison/JS-Minify/master/META6.json


### PR DESCRIPTION
JavaScript minifier module for Perl 6. This is a port of the Perl JavaScript::Minifier module.