### PR TITLE
Pod::Render module

### DIFF
--- a/META.list
+++ b/META.list
@@ -738,3 +738,4 @@ https://raw.githubusercontent.com/jsimonet/dns-zone/master/META.info
 https://raw.githubusercontent.com/jonathanstowe/URI-FetchFile/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Monitor-Monit/master/META6.json
 https://raw.githubusercontent.com/titsuki/p6-MeCab/master/META6.json
+https://raw.githubusercontent.com/MARTIMM/pod-render/master/META.info


### PR DESCRIPTION
Pod::Render module and pod-render program to render pod to html using Pod::To:HTML and markdown using Pod::To::Markdown. First can also be converted to pdf using wkhtmltopdf when installed. The module is a sort of wrapper to add better css support.