### PR TITLE
Add  Sparrowdo::Ruby::Bundler to ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -760,3 +760,4 @@ https://raw.githubusercontent.com/melezhik/sparrowdo-chef-client/master/META.inf
 https://raw.githubusercontent.com/jnthn/p6-test-scheduler/master/META6.json
 https://raw.githubusercontent.com/dugword/Number-Bytes-Human/master/META6.json
 https://raw.githubusercontent.com/JJ/p6-math-constants/master/META6.json
+https://github.com/melezhik/sparrowdo-ruby-bundler/blob/master/META6.json


### PR DESCRIPTION
Sparrowdo module to manage Ruby gems via Ruby bundler.