### PR TITLE
Take over Git::Wrapper

### DIFF
--- a/META.list
+++ b/META.list
@@ -247,7 +247,7 @@ https://raw.githubusercontent.com/tony-o/perl6-web-scraper/master/META.info
 https://raw.githubusercontent.com/avuserow/perl6-audio-taglib-simple/master/META.info
 https://raw.githubusercontent.com/tony-o/perl6-html-parser-xml/master/META.info
 https://raw.githubusercontent.com/avuserow/perl6-compress-snappy/master/META.info
-https://raw.githubusercontent.com/perlpilot/p6-Git-Wrapper/master/META.info
+https://raw.githubusercontent.com/nicqrocks/p6-Git-Wrapper/master/META.info
 https://raw.githubusercontent.com/perl6/gtk-simple/master/META6.json
 https://raw.githubusercontent.com/timo/cairo-p6/master/META6.json
 https://raw.githubusercontent.com/tadzik/ClassX-StrictConstructor/master/META.info


### PR DESCRIPTION
Given permission by @perlpilot (see: https://irclog.perlgeek.de/perl6/2017-01-13#i_13915698), I would like to take over maintenance of the Git::Wrapper module.