### PR TITLE
Take over Net::XMPP

### DIFF
--- a/META.list
+++ b/META.list
@@ -127,7 +127,7 @@ https://raw.githubusercontent.com/retupmoca/P6-Net-POP3/master/META.info
 https://raw.githubusercontent.com/retupmoca/P6-Net-IMAP/master/META.info
 https://raw.githubusercontent.com/retupmoca/P6-Digest-HMAC/master/META.info
 https://raw.githubusercontent.com/retupmoca/P6-Net-SOCKS/master/META.info
-https://raw.githubusercontent.com/retupmoca/P6-Net-XMPP/master/META.info
+https://raw.githubusercontent.com/kalkin/Net-XMPP/master/META6.json
 https://raw.githubusercontent.com/retupmoca/P6-Net-AMQP/master/META.info
 https://raw.githubusercontent.com/retupmoca/P6-SOAP/master/META.info
 https://raw.githubusercontent.com/retupmoca/P6-UUID/master/META.info


### PR DESCRIPTION
I updated the project to current Socket API & merged outstanding pull requests. Given that the current `Net::XMPP` library isn't working at all with the current `Perl 6.c` version, the author is barely active on GitHub and seems to ignore PRs I assume he isn't interested in it any more. May I take over? 

I'm engaged in the XMPP community and currently working on improving and extending the XMPP support for Perl6, so I will actively maintain this project.