### PR TITLE
Remove NCurses6 from ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -809,7 +809,6 @@ https://raw.githubusercontent.com/melezhik/perl6-sparrowdo-rvm/master/META6.json
 https://raw.githubusercontent.com/gfldex/perl6-slippy-semilist/master/META6.json
 https://raw.githubusercontent.com/CurtTilmes/Perl6-GraphQL/master/META6.json
 https://raw.githubusercontent.com/melezhik/perl6-sparrowdo-rakudo/master/META6.json
-https://raw.githubusercontent.com/blippy/perl6-ncurses6/master/META6.json
 https://raw.githubusercontent.com/jnthn/p6-io-socket-async-ssl/master/META6.json
 https://raw.githubusercontent.com/p6-pdf/perl6-Native-Packing/master/META6.json
 https://raw.githubusercontent.com/jsimonet/log-any/master/META6.json


### PR DESCRIPTION
My NCurses6 module at
`https://github.com/blippy/perl6-ncurses6`
is obviated by recent changes to upstream:
`https://github.com/azawawi/perl6-ncurses`

Therefore `NCurses6` should be removed as a redundant package