### PR TITLE
Added MinG.

### DIFF
--- a/META.list
+++ b/META.list
@@ -813,3 +813,4 @@ https://raw.githubusercontent.com/p6-pdf/perl6-Native-Packing/master/META6.json
 https://raw.githubusercontent.com/jsimonet/log-any/master/META6.json
 https://raw.githubusercontent.com/matiaslina/perl6-matrix-client/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/MessagePack-Class/master/META6.json
+https://raw.githubusercontent.com/IanTayler/MinG/master/META6.json


### PR DESCRIPTION
MinG is a module for working with Minimalist Grammars: a mildly-context-sensitive formalism first described by Edward Stabler in 1996. MinG::S13 is an implementation of Stabler's 2012/2013 parser for Minimalist Grammars.