### PR TITLE
Add travis tests for newly added packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: perl6
 perl6:
   - latest
+before_install:
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "Please disable builds on branch updates in settings."; travis_terminate 0; fi
 
 install:
   - rakudobrew build zef

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: perl6
+perl6:
+  - latest
+
+install:
+  - rakudobrew build zef
+
+script:
+  - zef install Test::META LWP::Simple IO::Socket::SSL
+  - perl6 ./.travis/testpackagemeta.pl

--- a/.travis/testpackagemeta.pl
+++ b/.travis/testpackagemeta.pl
@@ -25,6 +25,8 @@ my $lines = 0;
 for split("\n", $metadiff.trim).map({ .trim; }) -> $line {
   $lines++;
   if $lines < 6 or $line !~~ /^\+/ {
+    # First 5 lines are git diff header
+    # Also we don't care about context or removed lines
     next;
   }
 

--- a/.travis/testpackagemeta.pl
+++ b/.travis/testpackagemeta.pl
@@ -1,0 +1,111 @@
+use v6;
+use LWP::Simple;
+use JSON::Fast;
+use Test;
+use Test::META;
+
+if ! defined %*ENV<TRAVIS_COMMIT_RANGE> {
+    say "TRAVIS_COMMIT_RANGE wasn't set, don't know what to do.";
+    exit 1;
+}
+
+my ($from, $to) = split("...", %*ENV<TRAVIS_COMMIT_RANGE>);
+
+my $diffproc = run 'git', 'diff', '--no-color', '-p', '-U0', $from, $to, '--', 'META.list', :out;
+my $metadiff = $diffproc.out.slurp;
+
+if $metadiff ~~ /^\s*$/ {
+  say "Nothing changed all fine.";
+  exit 0;
+}
+
+my @urls = ();
+my $lines = 0;
+
+for split("\n", $metadiff.trim).map({ .trim; }) -> $line {
+  $lines++;
+  if $lines < 6 or $line !~~ /^\+/ {
+    next;
+  }
+
+  my $metaurl = substr $line, 1;
+  @urls.push: $metaurl;
+}
+
+if (@urls.end lt 0) {
+  say "No packages have been added.";
+  exit 0;
+}
+
+my $amountUrls = @urls.end + 1;
+say "$amountUrls packages were added";
+
+plan $amountUrls;
+
+my $lwp = LWP::Simple.new();
+
+my $oldpwd = $*CWD;
+
+my @failed = ();
+
+for @urls -> $url {
+  my $subres = subtest {
+    my $sourcedir;
+    my $res = lives-ok {
+      my $resp = $lwp.get($url);
+      if ! defined $resp {
+          fail "$url not reachable";
+          return;
+      }
+
+      my $meta = from-json($resp);
+
+      if ! $meta<source-url> {
+          fail "no source-url defined in META file";
+          return;
+      }
+
+      $_ = $meta<name>;
+      s:g/\:\:/__/;
+      $sourcedir = $*TMPDIR ~ "/" ~ $_;
+      my $sourceurl = $meta<source-url>;
+      my $git = run "git", "clone", $sourceurl, $sourcedir;
+      if $git.exitcode ne 0 {
+        fail "Couldn't clone repo " ~ $sourceurl;
+        return;
+      }
+    }, "Downloading $url";
+
+    if $res {
+        chdir($sourcedir);
+
+        my $*DIST-DIR = $sourcedir.IO;
+        my $*TEST-DIR //= Any;
+        my $*META-FILE //= Any;
+        meta-ok();
+
+        my $zef = run "zef", "install", "--depsonly", "--/build", ".";
+        ok $zef.exitcode eq 0, "Able to install deps";
+        $zef = run "zef", "test", ".";
+        ok $zef.exitcode eq 0, "Package tests pass";
+
+        rm-all($sourcedir.IO);
+        chdir($oldpwd);
+    }
+  }, "Checking correctness of $url";
+
+  if ! $subres {
+      @failed.push: $url;
+  }
+}
+
+say "\nThe following urls failed:\n" ~ @failed.join("\n");
+
+# When we have a directory first recurse, then remove it
+multi sub rm-all(IO::Path $path where :d) {
+    .&rm-all for $path.dir;
+    rmdir($path)
+}
+
+# Otherwise just remove the thing directly
+multi sub rm-all(IO::Path $path) { $path.unlink }

--- a/.travis/testpackagemeta.pl
+++ b/.travis/testpackagemeta.pl
@@ -16,28 +16,14 @@ my $metadiff = $diffproc.out.slurp;
 
 if $metadiff ~~ /^\s*$/ {
   say "Nothing changed all fine.";
-  exit 0;
+  exit;
 }
 
-my @urls = ();
-my $lines = 0;
-
-for split("\n", $metadiff.trim).map({ .trim; }) -> $line {
-  $lines++;
-  if $lines < 6 or $line !~~ /^\+/ {
-    # First 5 lines are git diff header
-    # Also we don't care about context or removed lines
-    next;
-  }
-
-  my $metaurl = substr $line, 1;
-  @urls.push: $metaurl;
-}
-
-if (@urls.end lt 0) {
-  say "No packages have been added.";
-  exit 0;
-}
+# Skip first 5 lines of `gif diff` header
+my @urls = $metadiff.lines[6..*].grep(/^\+/)».substr(1) or do {
+    say "No packages have been added";
+    exit;
+};
 
 my $amountUrls = @urls.end + 1;
 say "$amountUrls packages were added";


### PR DESCRIPTION
This PR adds Travis tests to PR's, and tests if the URL added is reachable, the META is correct and dependecies are installable.

in Travis you should disable the option that it builds every master push since it doesn't know what to do then.