### PR TITLE
Update TagLibC url

### DIFF
--- a/META.list
+++ b/META.list
@@ -814,4 +814,4 @@ https://raw.githubusercontent.com/jsimonet/log-any/master/META6.json
 https://raw.githubusercontent.com/matiaslina/perl6-matrix-client/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/MessagePack-Class/master/META6.json
 https://raw.githubusercontent.com/IanTayler/MinG/master/META6.json
-https://raw.githubusercontent.com/the-eater/P6-TagLibC/master/META6.json
+https://raw.githubusercontent.com/PostCocoon/P6-TagLibC/master/META6.json


### PR DESCRIPTION
I moved TagLibC to an org. 
