### PR TITLE
Remove IO::Prompt because it is uploaded to cpan

### DIFF
--- a/META.list
+++ b/META.list
@@ -558,7 +558,6 @@ https://raw.githubusercontent.com/zhouzhen1/perl6-Inline-Scheme-Gambit/master/ME
 https://raw.githubusercontent.com/kuerbis/Term-Choose-p6/master/META6.json
 https://raw.githubusercontent.com/hankache/Acme-Cow/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Oyatul/master/META6.json
-https://raw.githubusercontent.com/wbiker/io-prompt/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Test-Util-ServerPort/master/META6.json
 https://raw.githubusercontent.com/titsuki/p6-Algorithm-BinaryIndexedTree/master/META6.json
 https://raw.githubusercontent.com/samgwise/Net-OSC/master/META6.json


### PR DESCRIPTION
I removed the IO::Prompt entry because I uploaded it to cpan instead.