### PR TITLE
Adding META entry for Format::Lisp

### DIFF
--- a/META.list
+++ b/META.list
@@ -869,3 +869,4 @@ https://raw.githubusercontent.com/stmuk/p6-panda-stub/master/META6.json
 https://raw.githubusercontent.com/erickjordan/perl6-Parse-STDF/master/META6.json
 https://raw.githubusercontent.com/zoffixznet/perl6-Pastebin-Shadowcat/master/META6.json
 https://raw.githubusercontent.com/W4anD0eR96/Algorithm-BitMap/master/META6.json
+https://raw.githubusercontent.com/drforr/perl6-Format-Lisp/master/META6.json


### PR DESCRIPTION
Thank you for submitting a module to the Perl 6 Ecosystem!

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
