### PR TITLE
Added Slang-AltTernary

### DIFF
--- a/META.list
+++ b/META.list
@@ -875,3 +875,4 @@ https://raw.githubusercontent.com/FCO/SupplyTimeWindow/master/META6.json
 https://raw.githubusercontent.com/marcoonroad/perl6-cuid/master/META6.json
 https://raw.githubusercontent.com/tony-o/perl6-koos/master/META6.json
 https://raw.githubusercontent.com/FCO/test-time/master/META6.json
+https://raw.githubusercontent.com/mryan/perl6-Slang-AltTernary/master/META6.json


### PR DESCRIPTION
Playing with Slangs by adding an alternative ternary operator

Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.perl6.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
