### PR TITLE
Fix "Add update for Ddt to v0.5.3"

### DIFF
--- a/META.list
+++ b/META.list
@@ -731,7 +731,10 @@ https://raw.githubusercontent.com/finanalyst/p6-task-popular/master/META6.json
 https://raw.githubusercontent.com/FCO/DateTime-Extended/master/META6.json
 https://raw.githubusercontent.com/kalkin/License-Software/master/META6.json
 https://raw.githubusercontent.com/kalkin/Pod-To-Latex/master/META6.json
-https://raw.githubusercontent.com/kalkin/Ddt/master/META6.json
+https://raw.githubusercontent.com/kalkin/Ddt/v0.3.2/META6.json
+https://raw.githubusercontent.com/kalkin/Ddt/v0.4.0/META6.json
+https://raw.githubusercontent.com/kalkin/Ddt/v0.4.3/META6.json
+https://raw.githubusercontent.com/kalkin/Ddt/v0.5.3/META6.json
 https://raw.githubusercontent.com/jnthn/p6-data-textorbinary/master/META6.json
 https://raw.githubusercontent.com/gfldex/perl6-git-config/master/META6.json
 https://raw.githubusercontent.com/ramiroencinas/perl6-Package-Updates/master/META6.json


### PR DESCRIPTION
This fixes the commit 518af6f212e900bfcdb794282695b8a973051d32.

- included back all the previous versions of Ddt.
- latest Ddt version uses also a tagged version.

See also ugexe's comment [here](https://github.com/perl6/ecosystem/pull/403#issuecomment-408608887)