### PR TITLE
Update META.list - Moved Term::Choose, Term::Choose::Util and Term::TablePrint to CPAN

### DIFF
--- a/META.list
+++ b/META.list
@@ -538,7 +538,6 @@ https://raw.githubusercontent.com/Gnouc/p6-linux-process-signalinfo/master/META6
 https://raw.githubusercontent.com/peelle/LendingClub/master/META6.json
 https://raw.githubusercontent.com/titsuki/p6-Algorithm-Treap/master/META6.json
 https://raw.githubusercontent.com/zhouzhen1/perl6-Inline-Scheme-Gambit/master/META.info
-https://raw.githubusercontent.com/kuerbis/Term-Choose-p6/master/META6.json
 https://raw.githubusercontent.com/hankache/Acme-Cow/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Oyatul/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Test-Util-ServerPort/master/META6.json
@@ -563,8 +562,6 @@ https://raw.githubusercontent.com/titsuki/p6-Algorithm-KdTree/master/META6.json
 https://raw.githubusercontent.com/donaldh/Perl6-RPi-GpioDirect/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Audio-Hydrogen/master/META6.json
 https://raw.githubusercontent.com/Perl6-Noise-Gang/Audio-PortAudio/master/META6.json
-https://raw.githubusercontent.com/kuerbis/Term-Choose-Util-p6/master/META6.json
-https://raw.githubusercontent.com/kuerbis/Term-TablePrint-p6/master/META6.json
 https://raw.githubusercontent.com/salortiz/DBDish-ODBC/master/META6.json
 https://raw.githubusercontent.com/kmwallio/Acme-Skynet/master/META6.json
 https://raw.githubusercontent.com/Perl6-Noise-Gang/Audio-PortMIDI/master/META6.json


### PR DESCRIPTION
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.perl6.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
