### PR TITLE
add GtkPlus [On the way]

### DIFF
--- a/META.list
+++ b/META.list
@@ -603,6 +603,7 @@ https://raw.githubusercontent.com/jnthn/p6-app-moarvm-heapanalyzer/master/META6.
 https://raw.githubusercontent.com/atweiden/txn-parser/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/App-ModuleSnap/master/META6.json
 https://raw.githubusercontent.com/Xliff/p6-audio-oggvorbis/master/META6.json
+https://raw.githubusercontent.com/Xliff/p6-GtkPlus/master/META6.json
 https://raw.githubusercontent.com/Perl6-Noise-Gang/Task-Noise/master/META6.json
 https://raw.githubusercontent.com/salortiz/JsonC/master/META6.json
 https://raw.githubusercontent.com/jonathanstowe/Audio-Fingerprint-Chromaprint/master/META6.json


### PR DESCRIPTION
GtkPlus provides GTK+ library binding for Perl 6

<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.perl6.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
