### PR TITLE
Revert "Update META.list with the BCP57 module"

### DIFF
--- a/META.list
+++ b/META.list
@@ -861,4 +861,3 @@ https://raw.githubusercontent.com/Kaiepi/p6-Hastebin/master/META6.json
 https://raw.githubusercontent.com/JJ/p6-app-squashathons/master/META6.json
 https://raw.githubusercontent.com/mtw/Perl6-Bio-ViennaNGS/master/META6.json
 https://raw.githubusercontent.com/XiKuuKy/Avolution-Emoji/master/META6.json
-https://raw.githubusercontent.com/alabamenhu/BCP47/master/META6.json


### PR DESCRIPTION
Reverts perl6/ecosystem#430
There's still something to fix in the META6.json, please check the travis report.