### PR TITLE
Add Net::RCON module to P6 ecosystem

### DIFF
--- a/META.list
+++ b/META.list
@@ -845,3 +845,4 @@ https://raw.githubusercontent.com/alabamenhu/BCP47/master/META6.json
 https://raw.githubusercontent.com/JJ/perl6-test-script-output/master/META6.json
 https://raw.githubusercontent.com/salortiz/NativeLibs/master/META6.json
 https://raw.githubusercontent.com/alabamenhu/UserLanguage/master/META6.json
+https://raw.githubusercontent.com/shuppet/p6-net-RCON/master/META6.json


### PR DESCRIPTION
<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.perl6.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
