### PR TITLE
Add Unicode Security

### DIFF
--- a/META.list
+++ b/META.list
@@ -642,7 +642,6 @@ https://raw.githubusercontent.com/melezhik/sparrowdo-chef-client/master/META6.js
 https://raw.githubusercontent.com/jnthn/p6-test-scheduler/master/META6.json
 https://raw.githubusercontent.com/dugword/Number-Bytes-Human/master/META6.json
 https://raw.githubusercontent.com/JJ/p6-math-constants/master/META6.json
-https://raw.githubusercontent.com/JJ/perl6-unicode-security/master/META6.json
 https://raw.githubusercontent.com/melezhik/sparrowdo-ruby-bundler/master/META6.json
 https://raw.githubusercontent.com/MARTIMM/tinky-hash/master/META6.json
 https://raw.githubusercontent.com/bradclawsie/Net-IP-Parse/master/META6.json
@@ -860,3 +859,5 @@ https://raw.githubusercontent.com/alabamenhu/Intl-CLDR/master/META6.json
 https://raw.githubusercontent.com/slunski/perl6-text-ldif/master/META6.json
 https://raw.githubusercontent.com/petrkol72/vCard-Parser/master/META6.json
 https://raw.githubusercontent.com/shuppet/p6-command-despatch/master/META6.json
+https://raw.githubusercontent.com/JJ/perl6-unicode-security/master/META6.json
+

--- a/META.list
+++ b/META.list
@@ -860,4 +860,3 @@ https://raw.githubusercontent.com/slunski/perl6-text-ldif/master/META6.json
 https://raw.githubusercontent.com/petrkol72/vCard-Parser/master/META6.json
 https://raw.githubusercontent.com/shuppet/p6-command-despatch/master/META6.json
 https://raw.githubusercontent.com/JJ/perl6-unicode-security/master/META6.json
-


### PR DESCRIPTION
(Actually moving it, but modules.perl6.org does not seem to have caught it)

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
