### PR TITLE
Skip empty lines in diff

### DIFF
--- a/.travis/testpackagemeta.p6
+++ b/.travis/testpackagemeta.p6
@@ -21,8 +21,8 @@ if $metadiff ~~ /^\s*$/ {
   exit;
 }
 
-# Skip first 5 lines of `gif diff` header
-my @urls = $metadiff.lines[5..*].grep(/^\+/)».substr(1) or do {
+# Skip first 5 lines of `gif diff` header, grep off empty lines
+my @urls = $metadiff.lines[5..*].grep(/^\+/)».substr(1).grep(*.trim.chars != 0) or do {
     say "No packages have been added";
     exit;
 };


### PR DESCRIPTION
An attempt to fix https://github.com/perl6/ecosystem/issues/452
Checked it locally with some newline commits, warnings are gone.