### PR TITLE
Switches to new version

### DIFF
--- a/META.list
+++ b/META.list
@@ -822,7 +822,7 @@ https://raw.githubusercontent.com/tony-o/perl6-event-emitter-interprocess/master
 https://raw.githubusercontent.com/edumentab/p6-ecma262regex/master/META6.json
 https://raw.githubusercontent.com/tmtvl/Zodiac-Chinese/master/META6.json
 https://raw.githubusercontent.com/0racle/p6-Exportable/master/META6.json
-https://raw.githubusercontent.com/finanalyst/pod-cached/master/META6.json
+https://raw.githubusercontent.com/perl6/Pod-To-Cached/master/META6.json
 https://raw.githubusercontent.com/ccworld1000/CCLog/master/META6.json
 https://raw.githubusercontent.com/ccworld1000/CCChart/master/META6.json
 https://raw.githubusercontent.com/ccworld1000/CCColor/master/META6.json


### PR DESCRIPTION
This version is community-maintained as part of the perl6 repos. It also contains a new version, 0.3.5

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
