### PR TITLE
renamed paths for Email::Valid and Sys::IP modules

### DIFF
--- a/META.list
+++ b/META.list
@@ -425,7 +425,7 @@ https://raw.githubusercontent.com/perl6-community-modules/perl6-Color/master/MET
 https://raw.githubusercontent.com/teodozjan/path6-coverage/master/META6.json
 https://raw.githubusercontent.com/p6-pdf/PDF-p6/master/META6.json
 https://raw.githubusercontent.com/pierre-vigier/Perl6-HTTP-Signature/master/META6.json
-https://raw.githubusercontent.com/Demayl/perl6-Email-Valid/master/META6.json
+https://raw.githubusercontent.com/Demayl/raku-Email-Valid/master/META6.json
 https://raw.githubusercontent.com/hartenfels/JavaScript-SpiderMonkey/master/META.info
 https://raw.githubusercontent.com/bluebear94/Math-Random/master/META6.json
 https://raw.githubusercontent.com/bradclawsie/Subsets-Common/master/META6.json
@@ -867,7 +867,7 @@ https://raw.githubusercontent.com/JJ/perl6-unicode-security/master/META6.json
 https://raw.githubusercontent.com/tony-o/perl6-json-path/master/META6.json
 https://raw.githubusercontent.com/0racle/p6-File-Stat/master/META6.json
 https://raw.githubusercontent.com/dmaestro/Seq-Bounded/master/META6.json
-https://raw.githubusercontent.com/Demayl/perl6-Sys-IP/master/META6.json
+https://raw.githubusercontent.com/Demayl/raku-Sys-IP/master/META6.json
 https://raw.githubusercontent.com/tmtvl/neural-net/master/META6.json
 https://raw.githubusercontent.com/antoniogamiz/Perl6-TypeGraph/master/META6.json
 https://raw.githubusercontent.com/antoniogamiz/Pod-Utilities/master/META6.json


### PR DESCRIPTION
<!--
Thank you for submitting a module to the Perl 6 Ecosystem!

[Uploading Perl 6 modules to CPAN](https://docs.perl6.org/language/modules#Upload_your_Module_to_CPAN) is the preferred way of distributing modules, since GitHub is not a CDN. If you have the option, please use that route instead of adding the module here.

If adding a new module please review the following check boxes and check the appropriate boxes by going to the preview tab and checking them interactively or alternatively replacing the space in the checkboxes with an X. Your work is appreciated and every module helps make the Perl 6 Ecosystem a bigger and better place ♥
-->

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/perl6/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
