### PR TITLE
Removing the original (broken) HTML::Template

### DIFF
--- a/META.list
+++ b/META.list
@@ -362,7 +362,6 @@ https://raw.githubusercontent.com/masak/crypt/master/META.info
 https://raw.githubusercontent.com/masak/data-pretty/master/META.info
 https://raw.githubusercontent.com/masak/druid/master/META.info
 https://raw.githubusercontent.com/masak/gge/master/META.info
-https://raw.githubusercontent.com/masak/html-template/master/META.info
 https://raw.githubusercontent.com/masak/perl6-literate/master/META.info
 https://raw.githubusercontent.com/masak/text-indented/master/META.info
 https://raw.githubusercontent.com/masak/ufo/master/META.info


### PR DESCRIPTION
Hello,

Konstantin Narkhov (creator of Pheix) fixed and polished this abandoned module and we agreed that I can publish it. It already lives in the "zef ecosystem" and since the original one has no versioning and wouldn't even install, I think it's appropriate to remove it from here, in the name of forgiveness > permission.