### PR TITLE
Update META.list  for module take over with name change.

### DIFF
--- a/META.list
+++ b/META.list
@@ -1,3 +1,4 @@
+https://raw.githubusercontent.com/0rir/raku-iup/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/Crust-Middleware-Session-Store-DBIish/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/P6-Finance-GDAX-API/master/META6.json
 https://raw.githubusercontent.com/adaptiveoptics/P6-Prompt-Gruff/master/META6.json
@@ -184,7 +185,6 @@ https://raw.githubusercontent.com/grondilu/symbol/master/META6.json
 https://raw.githubusercontent.com/grondilu/trigpi/master/META6.json
 https://raw.githubusercontent.com/hankache/Acme-Cow/master/META6.json
 https://raw.githubusercontent.com/hankache/perl6-Imlib2/master/META6.json
-https://raw.githubusercontent.com/hankache/perl6-IUP/master/META6.json
 https://raw.githubusercontent.com/hipek8/p6-Statistics-LinearRegression/master/META6.json
 https://raw.githubusercontent.com/hipek8/p6-UNIX-Daemonize/master/META6.json
 https://raw.githubusercontent.com/hoelzro/p6-priorityqueue/master/META6.json


### PR DESCRIPTION
Naoum Hankache suggested this edit so that people will be directed to a more recent  
     IUP.rakumod
with more coverage of IUP, multis, and a modernized Raku style.

<!

- [X] I **agree** to the usage of the META file as listed [here](https://github.com/Raku/ecosystem#legal).

- [X] I have a license field listed in my META file that is one of https://spdx.org/licenses
  - [ ] My license is not one of those found on spdx.org but I **do** have a license field.
        In this case make sure you have a license URL listed under support. [See this example](https://github.com/samcv/URL-Find/blob/master/META6.json).
   - [ ] I **don't** have a license field. Yes, I understand this is **not recommended**.
